### PR TITLE
Add hubot-wpgtransit

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -2,5 +2,6 @@
     "hubot-redis-brain",
     "hubot-shipit",
     "hubot-stache",
-    "hubot-twitterstream-script"
+    "hubot-twitterstream-script",
+    "hubot-wpgtransit"
 ]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^4.1.0",
     "hubot-stache": "0.0.4",
-    "hubot-twitterstream-script": "neufeldtech/hubot-twitterstream-script"
+    "hubot-twitterstream-script": "neufeldtech/hubot-twitterstream-script",
+    "hubot-wpgtransit": "^0.1.0"
   },
   "scripts": {
     "start": "bin/hubot",


### PR DESCRIPTION
This is to add [hubot-wpgtransit](https://www.npmjs.com/package/hubot-wpgtransit) script.
I have already added the required API key environment variable to the Travis build.
